### PR TITLE
Fix missing await in sales JWT checks

### DIFF
--- a/src/app/api/sales/[id]/route.ts
+++ b/src/app/api/sales/[id]/route.ts
@@ -22,7 +22,7 @@ export async function GET(
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
     
-    const payload = verifyJwt(token);
+    const payload = await verifyJwt(token);
     if (!payload) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
@@ -57,7 +57,7 @@ export async function PUT(
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
     
-    const payload = verifyJwt(token);
+    const payload = await verifyJwt(token);
     if (!payload) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
@@ -122,7 +122,7 @@ export async function DELETE(
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
     
-    const payload = verifyJwt(token);
+    const payload = await verifyJwt(token);
     if (!payload) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/sales/route.ts
+++ b/src/app/api/sales/route.ts
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
     
-    const payload = verifyJwt(token);
+    const payload = await verifyJwt(token);
     if (!payload) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
     
-    const payload = verifyJwt(token);
+    const payload = await verifyJwt(token);
     if (!payload) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- ensure JWT verification is awaited in sales API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848203857a88328a1e0a2eb3a60a81b